### PR TITLE
Add support for MAPI format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/rich-text-resolver",
-  "version": "1.0.1",
+  "version": "1.1.0-beta",
   "private": false,
   "description": "Kontent.ai rich text element resolver and PortableText transformer for JavaScript and TypeScript",
   "license": "MIT",

--- a/showcase/showcase.ts
+++ b/showcase/showcase.ts
@@ -6,7 +6,8 @@ import { PortableTextComponent, PortableTextImage, PortableTextInternalLink, Por
     component: {
       _ref: "linkedItemOrComponentCodename",
       _type: "reference",
-    }
+    },
+    dataType: "component"
   };
   
   const portableTextImage: PortableTextImage = {

--- a/src/parser/parser-models.ts
+++ b/src/parser/parser-models.ts
@@ -17,7 +17,7 @@ export interface DomTextNode {
 /**
  * Represents a HTML tag.
  */
-export interface DomHtmlNode {
+export interface DomHtmlNode<TAttributes = Record<string, string | undefined>> {
   type: "tag";
   /**
    * Name of the HTML tag.
@@ -26,7 +26,7 @@ export interface DomHtmlNode {
   /**
    * Record of all the HTML tag's attributes and their values.
    */
-  attributes: Record<string, string>;
+  attributes: TAttributes & Record<string, string | undefined>;
   /**
    * Array of childnodes.
    */
@@ -39,3 +39,47 @@ export interface DomHtmlNode {
 export interface ParseResult {
   children: DomNode[];
 }
+
+type DeliverObjectElementAttributes = {
+  'data-rel': 'component' | 'link';
+  'data-type': 'item';
+  'data-codename': string;
+  'data-id': undefined;
+}
+
+type ManagementObjectElementAttributes = {
+  'data-rel': undefined;
+  'data-type': 'item' | 'component';
+  'data-id': string;
+  'data-codename': undefined;
+}
+
+export type AssetLinkElementAttributes = {
+  'data-asset-id': string;
+  'href'?: string;
+}
+
+export type ItemLinkElementAttributes = {
+  'data-item-id': string;
+  'href'?: string;
+}
+
+export type FigureElementAttributes = {
+  'data-asset-id': string;
+  'data-image-id'?: string;
+}
+
+export type ImgElementAttributes = {
+  'src': string;
+  'data-asset-id': string;
+  'data-image-id'?: string;
+  'alt'?: string;
+}
+
+export type InternalLinkElementAttributes =
+  | AssetLinkElementAttributes
+  | ItemLinkElementAttributes;
+
+export type ObjectElementAttributes = 
+  | DeliverObjectElementAttributes 
+  | ManagementObjectElementAttributes;

--- a/src/parser/parser-models.ts
+++ b/src/parser/parser-models.ts
@@ -44,14 +44,14 @@ type DeliverObjectElementAttributes = {
   'data-rel': 'component' | 'link';
   'data-type': 'item';
   'data-codename': string;
-  'data-id': undefined;
+  'data-id': never;
 }
 
 type ManagementObjectElementAttributes = {
   'data-rel': undefined;
   'data-type': 'item' | 'component';
   'data-id': string;
-  'data-codename': undefined;
+  'data-codename': never;
 }
 
 export type AssetLinkElementAttributes = {

--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -291,9 +291,10 @@ const transformTableCell: TransformTableCellFunction = (node) => {
 };
 
 const transformItem: TransformElementFunction = (node) => {
+    // data-codename reference is for DAPI, data-id for MAPI
     const itemReference: Reference = {
         _type: 'reference',
-        _ref: node.attributes['data-codename']
+        _ref: node.attributes['data-codename'] ?? node.attributes['data-id']
     }
 
     return [createComponentBlock(uid().toString(), itemReference)];

--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -261,7 +261,7 @@ const transformImage: TransformElementFunction = (node) => {
     const imageTag = node.children[0] as DomHtmlNode;
     const block = createImageBlock(uid().toString());
 
-    block.asset._ref = node.attributes['data-image-id'];
+    block.asset._ref = node.attributes['data-asset-id'];
     block.asset.url = imageTag.attributes['src'];
     block.asset.alt = imageTag.attributes['alt'];
 

--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -2,6 +2,7 @@ import { PortableTextBlock,PortableTextListItemType } from '@portabletext/types'
 
 import { DomHtmlNode, DomNode, ParseResult } from "../../parser/index.js"
 import {
+    ModularContentType,
     PortableTextItem,
     PortableTextLink,
     PortableTextObject,
@@ -297,7 +298,18 @@ const transformItem: TransformElementFunction = (node) => {
         _ref: node.attributes['data-codename'] ?? node.attributes['data-id']
     }
 
-    return [createComponentBlock(uid().toString(), itemReference)];
+    /**
+     * data-rel is only present in DAPI and acts as a differentiator
+     * between component and linked item in rich text
+     * 
+     * data-type is present in both DAPI and MAPI but differentiates
+     * only in the latter
+     */
+    const modularContentType =
+    (node.attributes["data-rel"] as ModularContentType) ??
+    (node.attributes["data-type"] as ModularContentType);
+
+    return [createComponentBlock(uid().toString(), itemReference, modularContentType)];
 }
 
 const transformLink: TransformLinkFunction = (node) => {

--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -295,7 +295,7 @@ const transformItem: TransformElementFunction<ObjectElementAttributes> = (node) 
     // data-codename reference is for DAPI, data-id for MAPI
     const itemReference: Reference = {
       _type: "reference",
-      _ref: node.attributes["data-codename"] ?? node.attributes["data-id"],
+      _ref: node.attributes["data-codename"] || node.attributes["data-id"],
     };
 
     /**
@@ -305,7 +305,7 @@ const transformItem: TransformElementFunction<ObjectElementAttributes> = (node) 
      * data-type is present in both DAPI and MAPI but differentiates
      * only in the latter
      */
-    const modularContentType = (node.attributes["data-rel"] ?? node.attributes["data-type"]) as ModularContentType;
+    const modularContentType = node.attributes['data-rel'] ?? node.attributes['data-type'] as ModularContentType;
 
     return [createComponentBlock(uid().toString(), itemReference, modularContentType)];
 }

--- a/src/transformers/transformer-models.ts
+++ b/src/transformers/transformer-models.ts
@@ -28,7 +28,7 @@ export interface AssetReference extends Reference {
   /**
    * Alternate image text.
    */
-  alt: string;
+  alt?: string;
 }
 
 /**
@@ -197,12 +197,16 @@ export type PortableTextInternalObject =
 export type PortableTextItem = PortableTextObject | PortableTextInternalObject;
 
 /**
- * `component` represents a rich text inline component
- * 
  * `link` and `item` represent a rich text linked item
  * in delivery and management API respectively
  */
-export type ModularContentType = "component" | "item" | "link";
+type DeliveryLinkedItem = "link";
+type ManagementLinkedItem = "item";
+
+/**
+ * `component` represents a rich text inline component
+ */
+export type ModularContentType = "component" | DeliveryLinkedItem | ManagementLinkedItem;
 
 
 /**

--- a/src/transformers/transformer-models.ts
+++ b/src/transformers/transformer-models.ts
@@ -108,6 +108,10 @@ export interface PortableTextTableCell extends ArbitraryTypedObject {
 export interface PortableTextComponent extends ArbitraryTypedObject {
   _type: "component";
   /**
+   * `component` for components or `item | link` for linked items
+   */
+  dataType: ModularContentType;
+  /**
    * Reference to a component or a linked item.
    */
   component: Reference;
@@ -191,6 +195,14 @@ export type PortableTextInternalObject =
  * Union of all default portable text object types.
  */
 export type PortableTextItem = PortableTextObject | PortableTextInternalObject;
+
+/**
+ * `component` represents a rich text inline component
+ * 
+ * `link` and `item` represent a rich text linked item
+ * in delivery and management API respectively
+ */
+export type ModularContentType = "component" | "item" | "link";
 
 
 /**

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,4 +1,4 @@
-import { DomHtmlNode, DomNode, DomTextNode, ItemLinkElementAttributes } from "../index.js";
+import { DomHtmlNode, DomNode, DomTextNode, FigureElementAttributes, ItemLinkElementAttributes, ObjectElementAttributes } from "../index.js";
 
 export const isOrderedListBlock = (node: DomHtmlNode): boolean =>
     node.tagName === 'ol';
@@ -31,19 +31,20 @@ export const isElement = (node: DomNode): node is DomHtmlNode =>
     node.type === 'tag';
 
 /**
- * Returns `true` if the node is a linked item node (`<object></object>`).
+ * Returns `true` if the node is a linked item node (`<object></object>`) and narrows type guard.
  */ 
-export const isLinkedItem = (node: DomNode): boolean =>
+export const isLinkedItem = (node: DomNode): node is DomHtmlNode<ObjectElementAttributes> =>
     isElement(node) && 
     node.tagName === 'object' &&
     node.attributes['type'] === 'application/kenticocloud';
+
 /**
- * Returns `true` if the node is a rich text image node (`<figure></figure>`).
+ * Returns `true` if the node is a rich text image node (`<figure></figure>`) and narrows type guard.
  */ 
-export const isImage = (node: DomNode): boolean =>
+export const isImage = (node: DomNode): node is DomHtmlNode<FigureElementAttributes> =>
     isElement(node) &&
     node.tagName === 'figure' &&
-    node.attributes['data-image-id'] ? true : false;
+    node.attributes['data-asset-id'] !== undefined;
 
 /**
  * Returns `true` if the node is a link to a content item and narrows type guard.

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,4 +1,4 @@
-import { DomHtmlNode, DomNode, DomTextNode } from "../index.js";
+import { DomHtmlNode, DomNode, DomTextNode, ItemLinkElementAttributes } from "../index.js";
 
 export const isOrderedListBlock = (node: DomHtmlNode): boolean =>
     node.tagName === 'ol';
@@ -46,7 +46,7 @@ export const isImage = (node: DomNode): boolean =>
     node.attributes['data-image-id'] ? true : false;
 
 /**
- * Returns `true` if the node is a link to a content item.
+ * Returns `true` if the node is a link to a content item and narrows type guard.
  */
-export const isItemLink = (node: DomHtmlNode): boolean =>
-    isAnchor(node) && !isExternalLink(node);
+export const isItemLink = (node: DomHtmlNode): node is DomHtmlNode<ItemLinkElementAttributes> =>
+    isAnchor(node) && node.attributes['data-item-id'] !== undefined;

--- a/src/utils/transformer-utils.ts
+++ b/src/utils/transformer-utils.ts
@@ -9,6 +9,7 @@ import ShortUniqueId from "short-unique-id";
 
 import { DomHtmlNode, DomTextNode } from "../parser/index.js";
 import {
+  ModularContentType,
   PortableTextComponent,
   PortableTextExternalLink,
   PortableTextImage,
@@ -251,11 +252,13 @@ export const createLinkMark = (
 
 export const createComponentBlock = (
   guid: string,
-  reference: Reference
+  reference: Reference,
+  dataType: ModularContentType
 ): PortableTextComponent => {
   return {
     _type: "component",
     _key: guid,
+    dataType,
     component: reference,
   };
 };

--- a/src/utils/transformer-utils.ts
+++ b/src/utils/transformer-utils.ts
@@ -55,12 +55,12 @@ export type IgnoredElement = typeof ignoredElements[number];
 export type MarkElement = typeof markElements[number];
 export type ValidElement = typeof allElements[number];
 
-export type TransformLinkFunction = (node: DomHtmlNode) => [PortableTextLink, PortableTextMark];
-export type TransformElementFunction = (node: DomHtmlNode) => PortableTextItem[];
+export type TransformLinkFunction<TElementAttributes = Record<string, string | undefined>> = (node: DomHtmlNode<TElementAttributes>) => [PortableTextLink, PortableTextMark];
+export type TransformElementFunction<TElementAttributes = Record<string, string | undefined>> = (node: DomHtmlNode<TElementAttributes>) => PortableTextItem[];
 export type TransformListItemFunction = (node: DomHtmlNode, depth: number, listType: PortableTextListItemType) => PortableTextStrictListItemBlock[];
 export type TransformTextFunction = (node: DomTextNode) => PortableTextSpan;
 export type TransformTableCellFunction = (node: DomHtmlNode) => PortableTextItem[];
-export type TransformFunction = TransformElementFunction | TransformListItemFunction;
+export type TransformFunction = TransformElementFunction<any> | TransformListItemFunction;
 
 export type MergePortableTextItemsFunction = (itemsToMerge: ReadonlyArray<PortableTextItem>) => PortableTextItem[];
 export type ResolverFunction<T extends ArbitraryTypedObject> = (value: T) => string;
@@ -217,7 +217,7 @@ export const createTableCell = (
 
 export const createExternalLink = (
   guid: string,
-  attributes: Readonly<Record<string, string>>
+  attributes: Readonly<Record<string, string | undefined>>
 ): PortableTextExternalLink => {
   return {
     _key: guid,

--- a/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
+++ b/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
@@ -78,7 +78,7 @@ exports[`portable text transformer doesn't extend link mark to adjacent spans 1`
 ]
 `;
 
-exports[`portable text transformer extends component with additional data 1`] = `
+exports[`portable text transformer extends component block with additional data 1`] = `
 [
   {
     "_key": "guid",
@@ -88,6 +88,7 @@ exports[`portable text transformer extends component with additional data 1`] = 
       "_ref": "test_item",
       "_type": "reference",
     },
+    "dataType": "link",
   },
 ]
 `;
@@ -270,6 +271,108 @@ exports[`portable text transformer resolves lists 1`] = `
     "listItem": "number",
     "markDefs": [],
     "style": "normal",
+  },
+]
+`;
+
+exports[`portable text transformer transforms a linked item and a component from DAPI with corresponding dataType 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Some text at the first level, followed by a component. ",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "n27ec1626_93ac_0129_64e5_1beeda45416c",
+      "_type": "reference",
+    },
+    "dataType": "component",
+  },
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "and a linked item",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "commercet",
+      "_type": "reference",
+    },
+    "dataType": "link",
+  },
+]
+`;
+
+exports[`portable text transformer transforms a linked item and a component from MAPI with corresponding dataType 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Some text at the first level, followed by a component. ",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "d6a10cb4-3639-429f-b6b0-b7fea6dec252",
+      "_type": "reference",
+    },
+    "dataType": "component",
+  },
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "and a linked item",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "99e17fe7-a215-400d-813a-dc3608ee0294",
+      "_type": "reference",
+    },
+    "dataType": "item",
   },
 ]
 `;
@@ -676,6 +779,7 @@ exports[`portable text transformer transforms complex rich text into portable te
       "_ref": "test_item",
       "_type": "reference",
     },
+    "dataType": "link",
   },
 ]
 `;
@@ -820,68 +924,6 @@ exports[`portable text transformer transforms item links 1`] = `
       },
     ],
     "style": "normal",
-  },
-]
-`;
-
-exports[`portable text transformer transforms linked item and a component from MAPI 1`] = `
-[
-  {
-    "_key": "guid",
-    "_type": "block",
-    "children": [
-      {
-        "_key": "guid",
-        "_type": "span",
-        "marks": [],
-        "text": "Some text at the first level, followed by a component. ",
-      },
-    ],
-    "markDefs": [],
-    "style": "normal",
-  },
-  {
-    "_key": "guid",
-    "_type": "component",
-    "component": {
-      "_ref": "d6a10cb4-3639-429f-b6b0-b7fea6dec252",
-      "_type": "reference",
-    },
-  },
-  {
-    "_key": "guid",
-    "_type": "block",
-    "children": [
-      {
-        "_key": "guid",
-        "_type": "span",
-        "marks": [],
-        "text": "and a linked item",
-      },
-    ],
-    "markDefs": [],
-    "style": "normal",
-  },
-  {
-    "_key": "guid",
-    "_type": "component",
-    "component": {
-      "_ref": "99e17fe7-a215-400d-813a-dc3608ee0294",
-      "_type": "reference",
-    },
-  },
-]
-`;
-
-exports[`portable text transformer transforms linked items/components 1`] = `
-[
-  {
-    "_key": "guid",
-    "_type": "component",
-    "component": {
-      "_ref": "test_item",
-      "_type": "reference",
-    },
   },
 ]
 `;

--- a/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
+++ b/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
@@ -274,6 +274,21 @@ exports[`portable text transformer resolves lists 1`] = `
 ]
 `;
 
+exports[`portable text transformer transforms asset from MAPI 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "image",
+    "asset": {
+      "_ref": "62ba1f17-13e9-43c0-9530-6b44e38097fc",
+      "_type": "reference",
+      "alt": undefined,
+      "url": "#",
+    },
+  },
+]
+`;
+
 exports[`portable text transformer transforms complex rich text into portable text 1`] = `
 [
   {
@@ -805,6 +820,55 @@ exports[`portable text transformer transforms item links 1`] = `
       },
     ],
     "style": "normal",
+  },
+]
+`;
+
+exports[`portable text transformer transforms linked item and a component from MAPI 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Some text at the first level, followed by a component. ",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "d6a10cb4-3639-429f-b6b0-b7fea6dec252",
+      "_type": "reference",
+    },
+  },
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "and a linked item",
+      },
+    ],
+    "markDefs": [],
+    "style": "normal",
+  },
+  {
+    "_key": "guid",
+    "_type": "component",
+    "component": {
+      "_ref": "99e17fe7-a215-400d-813a-dc3608ee0294",
+      "_type": "reference",
+    },
   },
 ]
 `;

--- a/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
+++ b/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
@@ -275,6 +275,73 @@ exports[`portable text transformer resolves lists 1`] = `
 ]
 `;
 
+exports[`portable text transformer transforms a link to an asset in DAPI 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Link to an ",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [
+          "guid",
+        ],
+        "text": "asset",
+      },
+    ],
+    "markDefs": [
+      {
+        "_key": "guid",
+        "_type": "link",
+        "data-asset-id": "bc6f3ce5-935d-4446-82d4-ce77436dd412",
+        "href": "https://assets-us-01.kc-usercontent.com:443/cec32064-07dd-00ff-2101-5bde13c9e30c/7d534724-edb8-4a6d-92f6-feb52be61d37/image1_w_metadata.jpg",
+      },
+    ],
+    "style": "normal",
+  },
+]
+`;
+
+exports[`portable text transformer transforms a link to an asset in MAPI 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Link to an ",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [
+          "guid",
+        ],
+        "text": "asset",
+      },
+    ],
+    "markDefs": [
+      {
+        "_key": "guid",
+        "_type": "link",
+        "data-asset-id": "bc6f3ce5-935d-4446-82d4-ce77436dd412",
+      },
+    ],
+    "style": "normal",
+  },
+]
+`;
+
 exports[`portable text transformer transforms a linked item and a component from DAPI with corresponding dataType 1`] = `
 [
   {

--- a/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
+++ b/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
@@ -385,4 +385,20 @@ describe("portable text transformer", () => {
     expect(nodeResult).toMatchSnapshot();
     expect(nodeResult).toMatchObject(browserResult);
   })
+
+  it("transforms a link to an asset in DAPI", () => {
+    const input = `<p>Link to an <a data-asset-id=\"bc6f3ce5-935d-4446-82d4-ce77436dd412\" href=\"https://assets-us-01.kc-usercontent.com:443/cec32064-07dd-00ff-2101-5bde13c9e30c/7d534724-edb8-4a6d-92f6-feb52be61d37/image1_w_metadata.jpg\">asset</a></p>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
+
+  it("transforms a link to an asset in MAPI", () => {
+    const input = `<p>Link to an <a data-asset-id=\"bc6f3ce5-935d-4446-82d4-ce77436dd412\">asset</a></p>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
 })

--- a/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
+++ b/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
@@ -363,7 +363,7 @@ describe("portable text transformer", () => {
   })
 
   it("transforms a linked item and a component from MAPI with corresponding dataType", () => {
-    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type=\"application/kenticocloud\" data-type=\"component\" data-id=\"d6a10cb4-3639-429f-b6b0-b7fea6dec252\"></object>\n<p>and a linked item</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-id=\"99e17fe7-a215-400d-813a-dc3608ee0294\"></object>`;
+    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type="application/kenticocloud" data-type="component" data-id="d6a10cb4-3639-429f-b6b0-b7fea6dec252"></object>\n<p>and a linked item</p>\n<object type="application/kenticocloud" data-type="item" data-id="99e17fe7-a215-400d-813a-dc3608ee0294"></object>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();
@@ -371,7 +371,7 @@ describe("portable text transformer", () => {
   })
 
   it("transforms asset from MAPI", () => {
-    const input = `<figure data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"><img src=\"#\" data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"></figure>`;
+    const input = `<figure data-asset-id="62ba1f17-13e9-43c0-9530-6b44e38097fc"><img src="#" data-asset-id="62ba1f17-13e9-43c0-9530-6b44e38097fc"></figure>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();
@@ -379,7 +379,7 @@ describe("portable text transformer", () => {
   })
 
   it("transforms a linked item and a component from DAPI with corresponding dataType", () => {
-    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n27ec1626_93ac_0129_64e5_1beeda45416c\"></object>\n<p>and a linked item</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"commercet\"></object>`;
+    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type="application/kenticocloud" data-type="item" data-rel="component" data-codename="n27ec1626_93ac_0129_64e5_1beeda45416c"></object>\n<p>and a linked item</p>\n<object type="application/kenticocloud" data-type="item" data-rel="link" data-codename="commercet"></object>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();
@@ -387,7 +387,7 @@ describe("portable text transformer", () => {
   })
 
   it("transforms a link to an asset in DAPI", () => {
-    const input = `<p>Link to an <a data-asset-id=\"bc6f3ce5-935d-4446-82d4-ce77436dd412\" href=\"https://assets-us-01.kc-usercontent.com:443/cec32064-07dd-00ff-2101-5bde13c9e30c/7d534724-edb8-4a6d-92f6-feb52be61d37/image1_w_metadata.jpg\">asset</a></p>`;
+    const input = `<p>Link to an <a data-asset-id="bc6f3ce5-935d-4446-82d4-ce77436dd412" href="https://assets-us-01.kc-usercontent.com:443/cec32064-07dd-00ff-2101-5bde13c9e30c/7d534724-edb8-4a6d-92f6-feb52be61d37/image1_w_metadata.jpg">asset</a></p>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();
@@ -395,7 +395,7 @@ describe("portable text transformer", () => {
   })
 
   it("transforms a link to an asset in MAPI", () => {
-    const input = `<p>Link to an <a data-asset-id=\"bc6f3ce5-935d-4446-82d4-ce77436dd412\">asset</a></p>`;
+    const input = `<p>Link to an <a data-asset-id="bc6f3ce5-935d-4446-82d4-ce77436dd412">asset</a></p>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();

--- a/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
+++ b/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
@@ -368,4 +368,20 @@ describe("portable text transformer", () => {
     expect(transformedResult).toMatchSnapshot();
     expect(nodeResult).toMatchObject(browserResult);
   })
+
+  it("transforms linked item and a component from MAPI", () => {
+    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type=\"application/kenticocloud\" data-type=\"component\" data-id=\"d6a10cb4-3639-429f-b6b0-b7fea6dec252\"></object>\n<p>and a linked item</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-id=\"99e17fe7-a215-400d-813a-dc3608ee0294\"></object>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
+
+  it("transforms asset from MAPI", () => {
+    const input = `<figure data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"><img src=\"#\" data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"></figure>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
 })

--- a/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
+++ b/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
@@ -257,13 +257,6 @@ describe("portable text transformer", () => {
     expect(nodeResult).toMatchSnapshot();
     expect(nodeResult).toMatchObject(browserResult);
   })
-  it("transforms linked items/components", () => {
-    const input = `<object type="application/kenticocloud" data-type="item" data-rel="link" data-codename="test_item"></object>`;
-    const { nodeResult, browserResult } = transformInput(input);
-
-    expect(nodeResult).toMatchSnapshot();
-    expect(nodeResult).toMatchObject(browserResult);
-  })
 
   it("doesn't create duplicates for nested spans", () => {
     const input = `<p>text<strong>bold</strong></p>`;
@@ -332,7 +325,7 @@ describe("portable text transformer", () => {
     expect(nodeResult).toMatchObject(browserResult);
   })
 
-  it("extends component with additional data", () => {
+  it("extends component block with additional data", () => {
     const input = `<object type="application/kenticocloud" data-type="item" data-rel="link" data-codename="test_item"></object>`;
 
     const processBlock = (block: PortableTextObject) => {
@@ -369,7 +362,7 @@ describe("portable text transformer", () => {
     expect(nodeResult).toMatchObject(browserResult);
   })
 
-  it("transforms linked item and a component from MAPI", () => {
+  it("transforms a linked item and a component from MAPI with corresponding dataType", () => {
     const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type=\"application/kenticocloud\" data-type=\"component\" data-id=\"d6a10cb4-3639-429f-b6b0-b7fea6dec252\"></object>\n<p>and a linked item</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-id=\"99e17fe7-a215-400d-813a-dc3608ee0294\"></object>`;
     const { nodeResult, browserResult } = transformInput(input);
 
@@ -379,6 +372,14 @@ describe("portable text transformer", () => {
 
   it("transforms asset from MAPI", () => {
     const input = `<figure data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"><img src=\"#\" data-asset-id=\"62ba1f17-13e9-43c0-9530-6b44e38097fc\"></figure>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
+
+  it("transforms a linked item and a component from DAPI with corresponding dataType", () => {
+    const input = `<p>Some text at the first level, followed by a component.&nbsp;</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n27ec1626_93ac_0129_64e5_1beeda45416c\"></object>\n<p>and a linked item</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"commercet\"></object>`;
     const { nodeResult, browserResult } = transformInput(input);
 
     expect(nodeResult).toMatchSnapshot();


### PR DESCRIPTION
### Motivation

Adjusts transformation logic for assets and components/linked items so that their representation in management API can also be parsed and transformed. Adds a new `dataType` attribute to `PortableTextComponent` in order to differentiate between components and linked items.

> [!IMPORTANT]
> HTML attributes on `object` tag are used to differentiate between linked items and components in the rich text.
>
> In DAPI, `data-rel` is used with either `component` or `link` value, `data-type` is `item` in both cases
> In MAPI, `data-type` is used with either `item` or `component` value, `data-rel` is not present
>
> For simplicity, I unionized all three possible values as a type for `dataType` property, to mirror the API response.
> Should we consider adding logic to determine whether the representation is DAPI/MAPI and get rid of the redundant third value (i.e. using only `item | component`)?


### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try transforming an output from management API with all the Kontent.ai specific objects (links, components, linked items, assets...).
