### PR TITLE
Bug: Return to custom findLastIndex for browser support

### DIFF
--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -26,6 +26,7 @@ import {
     createTable,
     createTableCell,
     createTableRow,
+    findLastIndex,
     IgnoredElement,
     ignoredElements,
     isElement,
@@ -76,7 +77,7 @@ export const transformToPortableText = (parsedTree: ParseResult): PortableTextOb
  * @param {PortableTextLink} linkItem - The link item (either internal or external) to be added to the text block's mark definitions.
  */
 const handleLinks = (mergedItems: PortableTextItem[], linkItem: PortableTextLink) => {
-    const lastBlockIndex = mergedItems.findLastIndex(item => item._type === 'block');
+    const lastBlockIndex = findLastIndex(mergedItems, item => item._type === 'block');
     if (lastBlockIndex !== -1) {
         const lastBlock = mergedItems[lastBlockIndex] as PortableTextBlock;
         lastBlock.markDefs = lastBlock.markDefs || [];

--- a/src/utils/transformer-utils.ts
+++ b/src/utils/transformer-utils.ts
@@ -270,6 +270,15 @@ export const compose = <T>(
     firstFunction
   );
 
+export const findLastIndex = <T>(arr: T[], predicate: (value: T) => boolean): number => {
+  for (let i = arr.length - 1; i >= 0; i--) {
+      if (predicate(arr[i])) {
+          return i;
+      }
+  }
+  return -1;
+}
+
 export const getAllNewLineAndWhiteSpace = /\n\s*/g;
 
 export const uid = new ShortUniqueId.default({length: 16});


### PR DESCRIPTION
### Motivation

With the update from version 0.0.5 to 1.0.0 i saw that you stopped using your own custom implementation of findLastIndex and started using the build-in version
![image](https://github.com/kontent-ai/rich-text-resolver-js/assets/50109737/11c6c988-6fd3-4d0f-8c6d-c5f8aca57ab8)
![image](https://github.com/kontent-ai/rich-text-resolver-js/assets/50109737/c5e86394-1321-42cc-8575-d4d03919f95e)

However, older browsers don't support the function findLastIndex and they throw this error.
![image](https://github.com/kontent-ai/rich-text-resolver-js/assets/50109737/12687d79-0fe9-4cc3-9053-4468eebeb840)

Therefore i would like to turn-back this change to make sure that this library also supports older browsers.
I've copied the findLastIndex function from release 0.0.5 so this is your own old implementation.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
