### PR TITLE
#48 - Fix duplicate external link marks

### DIFF
--- a/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -126,9 +126,10 @@ const mergeSpansAndMarks: MergePortableTextItemsFunction = (itemsToMerge) => {
                  * 
                  * in this case, a link can have multiple child nodes if some of its text is styled. 
                  * as a result, keeping a counter for the link's children and decrementing it with each subsequent span occurrence
-                 * is required so that the link mark doesn't extend beyond its scope. 
+                 * is required so that the link mark doesn't extend beyond its scope. links array is reset when the counter reaches zero.
                  */
-                item.marks = [...marks, ...(linkChildCount > 0 ? links : [])];
+                links = linkChildCount > 0 ? links : [];
+                item.marks = [...marks, ...links];
                 // ensures the child count doesn't go below zero
                 linkChildCount = Math.max(0, linkChildCount - 1);
                 mergedItems.push(item);

--- a/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
+++ b/tests/transfomers/portable-text-transformer/__snapshots__/portable-text-transformer.spec.ts.snap
@@ -12227,3 +12227,61 @@ exports[`portable text transformer transforms table with input <table><tbody><tr
   },
 ]
 `;
+
+exports[`portable text transformer with multiple links in a paragraph, doesn't extend linkmark beyond the first 1`] = `
+[
+  {
+    "_key": "guid",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": "Text ",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [
+          "guid",
+        ],
+        "text": "inner text 1",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": " text between ",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [
+          "guid",
+        ],
+        "text": "inner text 2",
+      },
+      {
+        "_key": "guid",
+        "_type": "span",
+        "marks": [],
+        "text": ".",
+      },
+    ],
+    "markDefs": [
+      {
+        "_key": "guid",
+        "_type": "link",
+        "href": "https://example.com",
+      },
+      {
+        "_key": "guid",
+        "_type": "link",
+        "href": "https://example.org",
+      },
+    ],
+    "style": "normal",
+  },
+]
+`;

--- a/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
+++ b/tests/transfomers/portable-text-transformer/portable-text-transformer.spec.ts
@@ -401,4 +401,12 @@ describe("portable text transformer", () => {
     expect(nodeResult).toMatchSnapshot();
     expect(nodeResult).toMatchObject(browserResult);
   })
+
+  it("with multiple links in a paragraph, doesn't extend linkmark beyond the first", () => {
+    const input = `<p>Text <a href="https://example.com">inner text 1</a> text between <a href="https://example.org">inner text 2</a>.</p>`;
+    const { nodeResult, browserResult } = transformInput(input);
+
+    expect(nodeResult).toMatchSnapshot();
+    expect(nodeResult).toMatchObject(browserResult);
+  })
 })


### PR DESCRIPTION
### Motivation

Fixes #48

Processing of external links incorrectly didn't reset link array when counter of child spans reached zero, resulting in duplicate links.  Added a condition to `mergeSpansAndMarks`.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Transform a paragraph with multiple external links and ensure the marks are not duplicated in the resulting portable text (snapshot test was added).