### PR TITLE
Faulty null handling

### DIFF
--- a/src/transformers/json-transformer/json-transformer.ts
+++ b/src/transformers/json-transformer/json-transformer.ts
@@ -26,9 +26,10 @@ const transformDomNode: TransformDomNodeType = (
   { resolveDomHtmlNode, resolveDomTextNode }: CustomResolversType,
 ) => {
   if (isText(node)) {
-    return resolveDomTextNode?.(node) ?? nodeIdentity(node);
+    return resolveDomTextNode ? resolveDomTextNode(node) : nodeIdentity(node);
   }
 
-  return resolveDomHtmlNode?.(node, (node) => transformDomNode(node, { resolveDomHtmlNode, resolveDomTextNode }))
-    ?? nodeIdentity(node);
+  return resolveDomHtmlNode
+    ? resolveDomHtmlNode(node, (node) => transformDomNode(node, { resolveDomHtmlNode, resolveDomTextNode }))
+    : nodeIdentity(node);
 };

--- a/tests/transfomers/json-transformer/json-transformer.spec.ts
+++ b/tests/transfomers/json-transformer/json-transformer.spec.ts
@@ -217,6 +217,26 @@ describe("Json Transfomer Tests", () => {
     expect(output).toEqual(expectedOutput);
   });
 
+  it("Test text transformer returning null", () => {
+    const testValue: ParseResult = {
+      children: [
+        {
+          type: "text",
+          content: "test value",
+        },
+      ],
+    };
+
+    const result = transformToJson(testValue, {
+      resolveDomTextNode: () => null,
+      resolveDomHtmlNode: null,
+    });
+
+    const expected = [null];
+
+    expect(result).toEqual(expected);
+  });
+
   it("Test RichText", () => {
     const parsed = browserParse(dummy.value);
     const transformed = transformJsonWithCustomResolvers(parsed);


### PR DESCRIPTION
### Motivation

refactor in version 1.2.0 introduced a bug where a `null` return value of a custom json transformer invoked faulty behavior. code in question has been reverted to a previous state, test has been added.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
