### PR TITLE
Fix defaults in HTML and React helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontent-ai/rich-text-resolver",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontent-ai/rich-text-resolver",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@portabletext/react": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontent-ai/rich-text-resolver",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "Kontent.ai rich text element resolver and PortableText transformer for JavaScript and TypeScript",
   "license": "MIT",

--- a/src/utils/resolution/html.ts
+++ b/src/utils/resolution/html.ts
@@ -43,7 +43,7 @@ type RichTextHtmlComponents = Omit<PortableTextHtmlComponents, "types" | "marks"
  * @returns HTML string
  */
 export const toHTML = (blocks: PortableTextObject[], resolvers?: PortableTextHtmlResolvers) => {
-  const defaultComponentResolvers: PortableTextHtmlResolvers = {
+  const kontentDefaultComponentResolvers: PortableTextHtmlResolvers = {
     components: {
       types: {
         image: ({ value }) => resolveImage(value),
@@ -68,11 +68,11 @@ export const toHTML = (blocks: PortableTextObject[], resolvers?: PortableTextHtm
   const mergedComponentResolvers = {
     ...resolvers?.components,
     types: {
-      ...defaultComponentResolvers.components.types,
+      ...kontentDefaultComponentResolvers.components.types,
       ...resolvers?.components.types,
     },
     marks: {
-      ...defaultComponentResolvers.components.marks,
+      ...kontentDefaultComponentResolvers.components.marks,
       ...resolvers?.components.marks,
     },
   };

--- a/src/utils/resolution/html.ts
+++ b/src/utils/resolution/html.ts
@@ -66,6 +66,7 @@ export const toHTML = (blocks: PortableTextObject[], resolvers?: PortableTextHtm
   };
 
   const mergedComponentResolvers = {
+    ...resolvers?.components,
     types: {
       ...defaultComponentResolvers.components.types,
       ...resolvers?.components.types,

--- a/src/utils/resolution/react.tsx
+++ b/src/utils/resolution/react.tsx
@@ -62,7 +62,7 @@ export const ImageComponent: React.FC<PortableTextImage> = (image) => (
   <img src={image.asset.url} alt={image.asset.alt ?? ""} />
 );
 
-const defaultComponentResolvers: PortableTextReactResolvers = {
+const kontentDefaultComponentResolvers: PortableTextReactResolvers = {
   types: {
     image: ({ value }) => <ImageComponent {...value} />,
     table: ({ value }) => <TableComponent {...value} />,
@@ -91,12 +91,13 @@ export const PortableText = <B extends TypedObject = PortableTextBlock>({
   onMissingComponent: missingComponentHandler,
 }: PortableTextProps<B>): JSX.Element => {
   const mergedComponentResolvers: PortableTextReactResolvers = {
+    ...componentOverrides,
     types: {
-      ...defaultComponentResolvers.types,
+      ...kontentDefaultComponentResolvers.types,
       ...componentOverrides?.types,
     },
     marks: {
-      ...defaultComponentResolvers.marks,
+      ...kontentDefaultComponentResolvers.marks,
       ...componentOverrides?.marks,
     },
   };

--- a/tests/components/__snapshots__/portable-text.spec.tsx.snap
+++ b/tests/components/__snapshots__/portable-text.spec.tsx.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`portable text React resolver renders a heading using custom resolvers 1`] = `"<h1 class="custom class">heading</h1>"`;
+
+exports[`portable text React resolver renders a heading using default fallback 1`] = `"<h1>heading</h1>"`;
+
 exports[`portable text React resolver renders a link using custom resolvers 1`] = `"<p><a href="http://google.com">external link</a></p>"`;
 
 exports[`portable text React resolver renders a resolved linked item 1`] = `"<div>random text value</div>"`;

--- a/tests/components/portable-text.spec.tsx
+++ b/tests/components/portable-text.spec.tsx
@@ -40,13 +40,17 @@ const dummyRichText: Elements.RichTextElement = {
 const portableTextComponents: PortableTextReactResolvers = {
   types: {
     componentOrItem: ({ value }) => {
-      const item = dummyRichText.linkedItems.find(item => item.system.codename === value.componentOrItem._ref);
+      const item = dummyRichText.linkedItems.find(
+        (item) => item.system.codename === value.componentOrItem._ref,
+      );
       return <div>{item?.elements.text_element.value}</div>;
     },
   },
   marks: {
     contentItemLink: ({ value, children }) => {
-      const item = dummyRichText.linkedItems.find(item => item.system.id === value?.contentItemLink._ref);
+      const item = dummyRichText.linkedItems.find(
+        (item) => item.system.id === value?.contentItemLink._ref,
+      );
       return (
         <a href={"https://somerandomwebsite.xyz/" + item?.system.codename}>
           {children}
@@ -57,11 +61,15 @@ const portableTextComponents: PortableTextReactResolvers = {
 };
 
 describe("portable text React resolver", () => {
-  const renderPortableText = (richTextValue: string, components = portableTextComponents) => {
+  const renderPortableText = (
+    richTextValue: string,
+    components = portableTextComponents,
+  ) => {
     dummyRichText.value = richTextValue;
     const portableText = transformToPortableText(dummyRichText.value);
 
-    return render(<PortableText value={portableText} components={components} />).container.innerHTML;
+    return render(<PortableText value={portableText} components={components} />)
+      .container.innerHTML;
   };
 
   it("renders simple HTML", () => {
@@ -146,6 +154,28 @@ describe("portable text React resolver", () => {
       <p><a href="http://google.com" title="linktitle" target="_blank">external link</a></p>
     `,
       customComponentResolvers,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders a heading using custom resolvers", () => {
+    const customComponentResolvers: PortableTextReactResolvers = {
+      ...portableTextComponents,
+      block: {
+        h1: ({ children }) => <h1 className="custom class">{children}</h1>,
+      },
+    };
+
+    const tree = renderPortableText(
+      `<h1>heading</h1>`,
+      customComponentResolvers,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders a heading using default fallback", () => {
+    const tree = renderPortableText(
+      `<h1>heading</h1>`,
     );
     expect(tree).toMatchSnapshot();
   });

--- a/tests/transfomers/portable-text-transformer/resolution/__snapshots__/html-resolver.spec.ts.snap
+++ b/tests/transfomers/portable-text-transformer/resolution/__snapshots__/html-resolver.spec.ts.snap
@@ -4,6 +4,12 @@ exports[`HTML resolution builds basic portable text into HTML 1`] = `"<p><br/></
 
 exports[`HTML resolution by default resolves text styled with sub and sup 1`] = `"<p><sub>Subscript text</sub><sup>Superscript text</sup></p>"`;
 
+exports[`HTML resolution resolves a h2 heading while using custom resolvers for h1 1`] = `"<h1 custom-attribute="value">modified heading</h1><h2>heading</h2>"`;
+
+exports[`HTML resolution resolves a heading using custom resolvers 1`] = `"<h1 custom-attribute="value">heading</h1>"`;
+
+exports[`HTML resolution resolves a heading using default fallback 1`] = `"<h1>heading</h1>"`;
+
 exports[`HTML resolution resolves a link using default fallback 1`] = `"<p><a href="https://website.com/12345" target="_blank" rel="noopener noreferrer">link</a></p>"`;
 
 exports[`HTML resolution resolves a linked item 1`] = `"<p>resolved value of text_element: <strong>random text value</strong></p><p>text after component</p>"`;

--- a/tests/transfomers/portable-text-transformer/resolution/html-resolver.spec.ts
+++ b/tests/transfomers/portable-text-transformer/resolution/html-resolver.spec.ts
@@ -87,9 +87,7 @@ describe("HTML resolution", () => {
     richTextValue: string,
     customResolvers?: PortableTextHtmlResolvers,
   ) => {
-    richTextInput.value = richTextValue;
-
-    const portableText = transformToPortableText(richTextInput.value);
+    const portableText = transformToPortableText(richTextValue);
     const result = toHTML(portableText, customResolvers);
 
     expect(result).toMatchSnapshot();

--- a/tests/transfomers/portable-text-transformer/resolution/html-resolver.spec.ts
+++ b/tests/transfomers/portable-text-transformer/resolution/html-resolver.spec.ts
@@ -13,75 +13,70 @@ jest.mock("short-unique-id", () => {
 });
 
 describe("HTML resolution", () => {
-  let richTextInput: Elements.RichTextElement;
-  let customResolvers: PortableTextHtmlResolvers;
-
-  beforeEach(() => {
-    richTextInput = {
-      value: "<p><br></p>",
-      type: ElementType.RichText,
-      images: [],
-      linkedItemCodenames: [],
-      linkedItems: [
-        {
-          system: {
-            id: "99e17fe7-a215-400d-813a-dc3608ee0294",
-            name: "test item",
-            codename: "test_item",
-            language: "default",
-            type: "test",
-            collection: "default",
-            sitemapLocations: [],
-            lastModified: "2022-10-11T11:27:25.4033512Z",
-            workflowStep: "published",
-            workflow: "default",
-          },
-          elements: {
-            text_element: {
-              type: ElementType.Text,
-              name: "text element",
-              value: "random text value",
-            },
-          },
+  const richTextInput: Elements.RichTextElement = {
+    value: "<p><br></p>",
+    type: ElementType.RichText,
+    images: [],
+    linkedItemCodenames: [],
+    linkedItems: [
+      {
+        system: {
+          id: "99e17fe7-a215-400d-813a-dc3608ee0294",
+          name: "test item",
+          codename: "test_item",
+          language: "default",
+          type: "test",
+          collection: "default",
+          sitemapLocations: [],
+          lastModified: "2022-10-11T11:27:25.4033512Z",
+          workflowStep: "published",
+          workflow: "default",
         },
-      ],
-      links: [],
-      name: "dummy",
-    };
-
-    customResolvers = {
-      components: {
-        block: {
-          h1: ({ children }) => `<h1 custom-attribute="value">${children}</h1>`,
-        },
-        types: {
-          image: ({ value }) => `<img src="${value.asset.url}" alt="${value.asset.rel ?? ""}" height="800">`,
-          componentOrItem: ({
-            value,
-          }: PortableTextTypeComponentOptions<PortableTextComponentOrItem>) => {
-            const linkedItem = richTextInput.linkedItems.find(
-              (item) => item.system.codename === value.componentOrItem._ref,
-            );
-            if (!linkedItem) {
-              return `Resolver for unknown type not implemented.`;
-            }
-
-            switch (linkedItem.system.type) {
-              case "test":
-                return `<p>resolved value of text_element: <strong>${linkedItem.elements.text_element.value}</strong></p>`;
-              default:
-                return `Resolver for type ${linkedItem.system.type} not implemented.`;
-            }
+        elements: {
+          text_element: {
+            type: ElementType.Text,
+            name: "text element",
+            value: "random text value",
           },
-        },
-        marks: {
-          contentItemLink: ({ children, value }) =>
-            `<a href="https://website.com/${value?.contentItemLink._ref}">${children}</a>`,
-          sup: ({ children }) => `<sup custom-attribute="value">${children}</sup>`,
         },
       },
-    };
-  });
+    ],
+    links: [],
+    name: "dummy",
+  };
+
+  const customResolvers: PortableTextHtmlResolvers = {
+    components: {
+      block: {
+        h1: ({ children }) => `<h1 custom-attribute="value">${children}</h1>`,
+      },
+      types: {
+        image: ({ value }) => `<img src="${value.asset.url}" alt="${value.asset.rel ?? ""}" height="800">`,
+        componentOrItem: ({
+          value,
+        }: PortableTextTypeComponentOptions<PortableTextComponentOrItem>) => {
+          const linkedItem = richTextInput.linkedItems.find(
+            (item) => item.system.codename === value.componentOrItem._ref,
+          );
+          if (!linkedItem) {
+            return `Resolver for unknown type not implemented.`;
+          }
+
+          switch (linkedItem.system.type) {
+            case "test":
+              return `<p>resolved value of text_element: <strong>${linkedItem.elements.text_element.value}</strong></p>`;
+            default:
+              return `Resolver for type ${linkedItem.system.type} not implemented.`;
+          }
+        },
+      },
+      marks: {
+        contentItemLink: ({ children, value }) =>
+          `<a href="https://website.com/${value?.contentItemLink._ref}">${children}</a>`,
+        sup: ({ children }) => `<sup custom-attribute="value">${children}</sup>`,
+      },
+    },
+  };
 
   const transformAndCompare = (
     richTextValue: string,


### PR DESCRIPTION
### Motivation

Merges of default components with overrides were not done properly in re-exported toHTML function and PortableText component, resulting in not being able to resolve blocks (h1, p...) and everything else besides `types` and `marks`. Added missing object spreads and tests to ensure both explicit resolution and fallback are working properly.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try to resolve something from `block` array, such as h1, while leaving h2 resolution unchanged, see that both headings are resolved as expected.
