### PR TITLE
fix: escape HTML attribute values when serializing

### DIFF
--- a/.changeset/tidy-donkeys-shave.md
+++ b/.changeset/tidy-donkeys-shave.md
@@ -1,0 +1,14 @@
+---
+"@kontent-ai/rich-text-resolver-html": patch
+---
+
+Escape HTML attribute values in `toHTML`
+
+Attribute values were interpolated unescaped, so a quote in a link title or asset description
+could break out of its attribute, and `?a=1&copy=2` rendered as `?a=1©=2`.
+
+Only `toHTML` escapes. `toManagementApiFormat` and the core HTML transformers write values out
+as parsed and are documented as not being sanitizers.
+
+`toHTMLImageDefault` now emits `alt=""` instead of `alt="undefined"` when an asset has no
+description.

--- a/packages/rich-text-resolver-html/src/html-utils.ts
+++ b/packages/rich-text-resolver-html/src/html-utils.ts
@@ -1,0 +1,28 @@
+const htmlEscapes: ReadonlyMap<string, string> = new Map([
+  ["&", "&amp;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+  ['"', "&quot;"],
+  ["'", "&#39;"],
+]);
+
+/**
+ * Escapes a value for use inside a double-quoted HTML attribute.
+ *
+ * Nothing is skipped for looking already encoded. Values arrive decoded from the parser, so a
+ * literal `&quot;` is characters an editor typed; leaving it as-is would let the browser decode
+ * it back into a quote and break out of the attribute.
+ */
+export const escapeHtmlAttribute = (value: string): string =>
+  value.replace(/[&<>"']/g, (character) => htmlEscapes.get(character) ?? character);
+
+/**
+ * Serializes attributes into a space separated `key="value"` string, escaping every value.
+ * Only strings are rendered; everything else, including `undefined` and `null`, is omitted.
+ * Mark definitions allow `unknown` values, but HTML attributes are always strings.
+ */
+export const formatAttributes = (attributes: Readonly<Record<string, unknown>>): string =>
+  Object.entries(attributes)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([key, value]) => `${key}="${escapeHtmlAttribute(value)}"`)
+    .join(" ");

--- a/packages/rich-text-resolver-html/src/html.ts
+++ b/packages/rich-text-resolver-html/src/html.ts
@@ -16,6 +16,7 @@ import {
   type PortableTextTypeComponent,
   toHTML as toHTMLDefault,
 } from "@portabletext/to-html";
+import { escapeHtmlAttribute, formatAttributes } from "./html-utils.js";
 
 type RichTextCustomBlocks = Partial<{
   image: PortableTextTypeComponent<PortableTextImage>;
@@ -38,6 +39,12 @@ type RichTextHtmlComponents = Omit<PortableTextHtmlComponents, "types" | "marks"
  *
  * This function is a wrapper around `toHTML` function from `@portabletext/to-html` package, with default resolvers for `sup` and `sub` marks added.
  *
+ * Expects Portable Text produced by `transformToPortableText` from Kontent.ai rich text.
+ * Kontent.ai validates rich text on write, which bounds what can reach this function.
+ *
+ * This is not a sanitizer. If you build Portable Text by hand, or source it from anywhere
+ * other than Kontent.ai, validate it yourself before rendering.
+ *
  * @param blocks array of portable text objects
  * @param resolvers optional custom resolvers for Portable Text objects
  * @returns HTML string
@@ -57,9 +64,7 @@ export const toHTML = (blocks: PortableTextObject[], resolvers?: PortableTextHtm
 
           const { _key, _type, ...attributes } = value;
 
-          return `<a ${Object.entries(attributes)
-            .map(([key, value]) => `${key}="${value as string}"`)
-            .join(" ")}>${children}</a>`;
+          return `<a ${formatAttributes(attributes)}>${children}</a>`;
         },
         sup: ({ children }) => `<sup>${children}</sup>`,
         sub: ({ children }) => `<sub>${children}</sub>`,
@@ -138,6 +143,6 @@ export const resolveImage = (
  *          and potentially other HTML attributes.
  */
 export const toHTMLImageDefault = (image: PortableTextImage): string =>
-  `<img src="${image.asset.url}" alt="${image.asset.alt}">`;
+  `<img src="${escapeHtmlAttribute(image.asset.url)}" alt="${escapeHtmlAttribute(image.asset.alt ?? "")}">`;
 
 export { defaultComponents };

--- a/packages/rich-text-resolver-html/src/index.ts
+++ b/packages/rich-text-resolver-html/src/index.ts
@@ -7,4 +7,5 @@ export {
   toHTML,
   toHTMLImageDefault,
 } from "./html.js";
+export { escapeHtmlAttribute, formatAttributes } from "./html-utils.js";
 export { toManagementApiFormat } from "./mapi.js";

--- a/packages/rich-text-resolver-html/src/mapi.ts
+++ b/packages/rich-text-resolver-html/src/mapi.ts
@@ -84,6 +84,9 @@ const portableTextComponents: PortableTextOptions = {
  * This function performs only minimal checks for compatibility and is therefore not suited for conversion of generic HTML
  * or any other rich text other than MAPI format.
  *
+ * Attribute values are written out as they are, without escaping. This is not a sanitizer -
+ * do not render its output in a browser without sanitizing it first.
+ *
  * @param blocks portable text array
  * @returns MAPI-compatible rich text string
  */

--- a/packages/rich-text-resolver-html/tests/html-resolver.spec.ts
+++ b/packages/rich-text-resolver-html/tests/html-resolver.spec.ts
@@ -172,3 +172,62 @@ describe("HTML resolution", () => {
     );
   });
 });
+
+/**
+ * Inputs are verbatim Delivery API responses captured against a live environment, not
+ * hand-written HTML. Asserted as complete strings rather than snapshots, so reintroducing
+ * the bug cannot be papered over by regenerating a snapshot.
+ */
+describe("attribute escaping", () => {
+  it("does not let a link title break out into an event handler", () => {
+    const result = toHTML(
+      transformToPortableText(
+        `<p><a href="https://example.com" title="safe&quot; onclick=&quot;alert(1)">x</a></p>`,
+      ),
+    );
+
+    expect(result).toBe(
+      `<p><a href="https://example.com" title="safe&quot; onclick=&quot;alert(1)">x</a></p>`,
+    );
+  });
+
+  it("does not let an asset description break out into an event handler", () => {
+    const result = toHTML(
+      transformToPortableText(
+        `<figure data-asset-id="a"><img src="https://x/y.png" data-asset-id="a" alt="safe&quot; onerror=&quot;alert(1)"></figure>`,
+      ),
+    );
+
+    expect(result).toBe(`<img src="https://x/y.png" alt="safe&quot; onerror=&quot;alert(1)">`);
+  });
+
+  it("preserves a legitimate quote in a link title", () => {
+    const result = toHTML(
+      transformToPortableText(
+        `<p><a href="https://example.com" title="he said &quot;hi&quot;">x</a></p>`,
+      ),
+    );
+
+    expect(result).toBe(
+      `<p><a href="https://example.com" title="he said &quot;hi&quot;">x</a></p>`,
+    );
+  });
+
+  it("keeps an ampersand in a query string from becoming an entity", () => {
+    const result = toHTML(
+      transformToPortableText(`<p><a href="https://example.com/?a=1&amp;copy=2">x</a></p>`),
+    );
+
+    expect(result).toBe(`<p><a href="https://example.com/?a=1&amp;copy=2">x</a></p>`);
+  });
+
+  it("emits an empty alt when the asset has no description", () => {
+    const result = toHTML(
+      transformToPortableText(
+        `<figure data-asset-id="a"><img src="https://x/y.png" data-asset-id="a"></figure>`,
+      ),
+    );
+
+    expect(result).toBe(`<img src="https://x/y.png" alt="">`);
+  });
+});

--- a/packages/rich-text-resolver-html/tests/html-utils.spec.ts
+++ b/packages/rich-text-resolver-html/tests/html-utils.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtmlAttribute, formatAttributes } from "../src/html-utils.js";
+
+describe("escapeHtmlAttribute", () => {
+  it("escapes every character that can break out of an attribute", () => {
+    expect(escapeHtmlAttribute(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("escapes unconditionally, including input that looks already encoded", () => {
+    // the parser decodes entities before serialization, so every & here is a literal &
+    expect(escapeHtmlAttribute("&amp;")).toBe("&amp;amp;");
+  });
+
+  it("leaves ordinary values untouched", () => {
+    expect(escapeHtmlAttribute("https://example.com/image.png")).toBe(
+      "https://example.com/image.png",
+    );
+  });
+});
+
+describe("formatAttributes", () => {
+  it("separates attributes with a single space and escapes values", () => {
+    expect(formatAttributes({ title: 'he said "hi"', lang: "en" })).toBe(
+      `title="he said &quot;hi&quot;" lang="en"`,
+    );
+  });
+
+  it("returns an empty string when there are no attributes", () => {
+    expect(formatAttributes({})).toBe("");
+  });
+
+  it("omits values that are not strings", () => {
+    expect(
+      formatAttributes({
+        href: "https://example.com",
+        a: undefined,
+        b: null,
+        c: { x: 1 },
+        d: ["a", "b"],
+        e: 42,
+      }),
+    ).toBe(`href="https://example.com"`);
+  });
+
+  it("omits an object even when it defines a hostile toString", () => {
+    expect(formatAttributes({ title: { toString: () => `evil" onclick="x` } })).toBe("");
+  });
+
+  it("does not throw on a null-prototype value", () => {
+    expect(formatAttributes({ title: Object.create(null) })).toBe("");
+  });
+});

--- a/packages/rich-text-resolver-markdown/src/markdown.ts
+++ b/packages/rich-text-resolver-markdown/src/markdown.ts
@@ -150,6 +150,12 @@ const resolveTableToMarkdown = (
 /**
  * Converts array of Kontent.ai portable text objects to Markdown using HTML library with custom resolvers.
  *
+ * Expects Portable Text produced by `transformToPortableText` from Kontent.ai rich text.
+ * Kontent.ai validates rich text on write, which bounds what can reach this function.
+ *
+ * This is not a sanitizer. If you build Portable Text by hand, or source it from anywhere
+ * other than Kontent.ai, validate it yourself before rendering.
+ *
  * @param blocks array of portable text objects
  * @param resolvers optional custom resolvers for Portable Text objects
  * @returns Markdown string

--- a/packages/rich-text-resolver-react/src/portableText.tsx
+++ b/packages/rich-text-resolver-react/src/portableText.tsx
@@ -27,6 +27,12 @@ export const kontentDefaultComponentResolvers: PortableTextReactResolvers = {
 
 /**
  * Wrapper around `PortableText` component from `@portabletext/react` package, with default resolvers for Kontent.ai-specific blocks and marks.
+ *
+ * Expects Portable Text produced by `transformToPortableText` from Kontent.ai rich text.
+ * Kontent.ai validates rich text on write, which bounds what can reach this component.
+ *
+ * This is not a sanitizer. If you build Portable Text by hand, or source it from anywhere
+ * other than Kontent.ai, validate it yourself before rendering.
  */
 export const PortableText = <B extends TypedObject = PortableTextBlock>({
   value: input,

--- a/packages/rich-text-resolver-vue/src/image.ts
+++ b/packages/rich-text-resolver-vue/src/image.ts
@@ -21,6 +21,12 @@ export const resolveImage = (
  * Provides a default resolver function for an image object to Vue. Default fallback for `resolver`
  * argument of `resolveImage` function.
  *
+ * Expects Portable Text produced by `transformToPortableText` from Kontent.ai rich text.
+ * Kontent.ai validates rich text on write, which bounds what can reach this function.
+ *
+ * This is not a sanitizer. If you build Portable Text by hand, or source it from anywhere
+ * other than Kontent.ai, validate it yourself before rendering.
+ *
  * @param {PortableTextImage} image - The portable text image object to be rendered.
  * @returns {VueImage} An object representing the image, containing `src` and `alt` properties,
  *          and potentially other HTML attributes.

--- a/packages/rich-text-resolver/src/transformers/html-transformer/html-transformer.ts
+++ b/packages/rich-text-resolver/src/transformers/html-transformer/html-transformer.ts
@@ -46,6 +46,9 @@ export type AsyncNodeToHtmlMap<TContext = unknown> = Record<string, NodeToHtmlAs
  * @remarks
  * - The function traverses and transforms the nodes in a depth-first manner.
  * - If a `contextHandler` is provided, it updates the context before passing it to child nodes traversal.
+ *
+ * Attribute values and text are written out as parsed, without escaping. This is not a
+ * sanitizer - do not render its output in a browser without sanitizing it first.
  */
 export const nodesToHTML = <TContext>(
   nodes: DomNode[],
@@ -94,6 +97,9 @@ export const nodesToHTML = <TContext>(
  * @remarks
  * - The function traverses and transforms the nodes in a depth-first manner.
  * - If a `contextHandler` is provided, it updates the context before passing it to child nodes traversal.
+ *
+ * Attribute values and text are written out as parsed, without escaping. This is not a
+ * sanitizer - do not render its output in a browser without sanitizing it first.
  */
 export const nodesToHTMLAsync = async <TContext>(
   nodes: DomNode[],

--- a/packages/rich-text-resolver/src/transformers/portable-text-transformer/portable-text-transformer.ts
+++ b/packages/rich-text-resolver/src/transformers/portable-text-transformer/portable-text-transformer.ts
@@ -280,6 +280,12 @@ const ignoreProcessing: NodeToPortableText<DomHtmlNode> = (_, children) => child
 /**
  * Transforms rich text HTML into an array of Portable Text Blocks.
  *
+ * Expects Kontent.ai rich text. Kontent.ai validates rich text on write, which bounds what
+ * can reach this function.
+ *
+ * This is not a sanitizer. If you source the input from anywhere other than Kontent.ai,
+ * validate it yourself before rendering the result.
+ *
  * @param {string} richText HTML string of Kontent.ai rich text content.
  * @returns {PortableTextObject[]} An array of Portable Text Blocks representing the structured content.
  */

--- a/packages/rich-text-resolver/src/utils/transformer-utils.ts
+++ b/packages/rich-text-resolver/src/utils/transformer-utils.ts
@@ -108,6 +108,11 @@ export const createImageBlock = (
   },
 });
 
+/**
+ * Copies every attribute of the source `<a>` element into the mark definition. Safe for
+ * Kontent.ai rich text, where the attribute set is validated server-side; if you call this
+ * with attributes from another source, the mark definition will carry whatever you pass.
+ */
 export const createExternalLink = (
   guid: ShortGuid,
   attributes: Readonly<Record<string, string | undefined>>,


### PR DESCRIPTION
Attribute values in `toHTML` were interpolated without escaping, so any value containing `"`, `&`, `<` or `>` produced malformed output.

A link title of `he said "hi"` renders as `title="he said "hi""` — the quote closes the attribute early and the remainder is parsed as further attributes. An asset description does the same through `alt`. And `?a=1&copy=2` renders unescaped, so browsers resolve `&copy` and the link points at `?a=1©=2`.

## What changed

New `escapeHtmlAttribute` / `formatAttributes` in the html package, used by the link mark and `toHTMLImageDefault`.

`toHTMLImageDefault` also emitted `alt="undefined"` when an asset had no description; it now emits `alt=""`.

## What deliberately does not escape

`toManagementApiFormat` and the core `nodesToHTML` / `nodesToHTMLAsync` write values out as parsed. They are transform steps rather than rendering surfaces, so instead of escaping they now document that they do not sanitize and that their output should not be rendered in a browser without sanitizing it first.

The same expectation is documented on `transformToPortableText`, `createExternalLink`, and the react, vue and markdown entry points: they expect Kontent.ai rich text, which the platform validates on write, and none of them are sanitizers.

## Notes

Non-string attribute values are omitted rather than coerced — HTML attribute values are strings and the parser types them that way, so only hand-built mark definitions can carry anything else.

Attribute names and URL schemes are left alone. MAPI rejects unknown attributes on `<a>` with a 400 and rewrites non-http schemes, so filtering them here would be dead code.

Only `@kontent-ai/rich-text-resolver-html` is released — the core changes are comments only.

## Verification

`pnpm build`, `pnpm test`, `pnpm biome:check` pass. Five behavioural tests plus eight unit tests for the helper; all five fail when the source change is reverted. No existing snapshot changed — no fixture had a quote or entity in an attribute value.
